### PR TITLE
Add Makefile for build and test workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+BIN_DIR := bin
+GATEWAY := $(BIN_DIR)/gateway
+SIMNET := $(BIN_DIR)/simnet
+
+ENDPOINT ?= 127.0.0.1:5001
+ADMIN ?= :8080
+ECHO_INTERVAL ?= 15s
+
+.PHONY: build sim gw test vet clean
+
+build: $(GATEWAY) $(SIMNET)
+
+$(GATEWAY):
+	go build -o $(GATEWAY) ./cmd/gateway
+
+$(SIMNET):
+	go build -o $(SIMNET) ./cmd/simnet
+
+sim: $(SIMNET)
+	$(SIMNET) -listen :5001
+
+gw: $(GATEWAY)
+	$(GATEWAY) -endpoint $(ENDPOINT) -admin $(ADMIN) -echo-interval $(ECHO_INTERVAL)
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+clean:
+	rm -f $(GATEWAY) $(SIMNET)


### PR DESCRIPTION
## Summary
- add a Makefile with build, sim, gw, test, vet and clean targets

## Testing
- `make build`
- `make vet`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b320d861588327ba4affa16b768cf8