### PR TITLE
Add ISO8583 secondary bitmap support

### DIFF
--- a/internal/iso8583/iso.go
+++ b/internal/iso8583/iso.go
@@ -11,7 +11,7 @@ import (
 
 // Message represents a minimal ISO8583 message used here.
 // MTI: 4 ASCII bytes
-// Bitmap: 8 bytes (primary)
+// Bitmap: 8 bytes primary (and optional secondary)
 // Supported fields in this skeleton: 7 (MMDDhhmmss), 11 (STAN, 6n), 70 (3n)
 type Message struct {
 	MTI    string
@@ -32,35 +32,60 @@ func (m *Message) Get(field int) (string, bool) { v, ok := m.Fields[field]; retu
 // Pack builds a wire message: [2B MLI][4B MTI ASCII][8B bitmap][fields...]
 // For our three fields, encoding is ASCII numeric, fixed-length except DE7 (10) and DE70 (3).
 func (m *Message) Pack() ([]byte, error) {
-	if len(m.MTI) != 4 { return nil, fmt.Errorf("invalid MTI: %q", m.MTI) }
+	if len(m.MTI) != 4 {
+		return nil, fmt.Errorf("invalid MTI: %q", m.MTI)
+	}
 
-	// Build bitmap
-	var bitmap uint64
-	set := func(bit int) { bitmap |= (1 << (64 - bit)) }
+	// Build bitmaps
+	var primary, secondary uint64
+	set := func(bit int) {
+		if bit <= 64 {
+			primary |= (1 << (64 - bit))
+		} else {
+			secondary |= (1 << (128 - bit))
+		}
+	}
 	for f := range m.Fields {
-		if f < 1 || f > 64 { return nil, fmt.Errorf("unsupported field %d", f) }
+		if f < 1 || f > 128 || f == 1 {
+			return nil, fmt.Errorf("unsupported field %d", f)
+		}
 		set(f)
+	}
+	if secondary != 0 {
+		primary |= (1 << 63) // bit 1 indicates secondary bitmap
 	}
 
 	body := bytes.NewBuffer(nil)
 	body.WriteString(m.MTI)
 	var bm [8]byte
-	binary.BigEndian.PutUint64(bm[:], bitmap)
+	binary.BigEndian.PutUint64(bm[:], primary)
 	body.Write(bm[:])
+	if secondary != 0 {
+		binary.BigEndian.PutUint64(bm[:], secondary)
+		body.Write(bm[:])
+	}
 
 	// Encode fields in numeric order
-	for f := 1; f <= 64; f++ {
+	for f := 2; f <= 128; f++ {
 		v, ok := m.Fields[f]
-		if !ok { continue }
+		if !ok {
+			continue
+		}
 		switch f {
 		case 7: // MMDDhhmmss (10n)
-			if len(v) != 10 { return nil, fmt.Errorf("DE7 must be 10 digits, got %d", len(v)) }
+			if len(v) != 10 {
+				return nil, fmt.Errorf("DE7 must be 10 digits, got %d", len(v))
+			}
 			body.WriteString(v)
 		case 11: // STAN (6n)
-			if len(v) != 6 { return nil, fmt.Errorf("DE11 must be 6 digits, got %d", len(v)) }
+			if len(v) != 6 {
+				return nil, fmt.Errorf("DE11 must be 6 digits, got %d", len(v))
+			}
 			body.WriteString(v)
 		case 70: // Network Mgmt Code (3n)
-			if len(v) != 3 { return nil, fmt.Errorf("DE70 must be 3 digits, got %d", len(v)) }
+			if len(v) != 3 {
+				return nil, fmt.Errorf("DE70 must be 3 digits, got %d", len(v))
+			}
 			body.WriteString(v)
 		default:
 			return nil, fmt.Errorf("field %d not implemented in skeleton", f)
@@ -76,31 +101,58 @@ func (m *Message) Pack() ([]byte, error) {
 
 // Unpack parses the minimal wire format from Pack().
 func Unpack(b []byte) (*Message, error) {
-	if len(b) < 2 { return nil, errors.New("buffer too short for MLI") }
+	if len(b) < 2 {
+		return nil, errors.New("buffer too short for MLI")
+	}
 	mli := int(binary.BigEndian.Uint16(b[:2]))
-	if len(b)-2 < mli { return nil, fmt.Errorf("incomplete message: need %d, have %d", mli, len(b)-2) }
+	if len(b)-2 < mli {
+		return nil, fmt.Errorf("incomplete message: need %d, have %d", mli, len(b)-2)
+	}
 	p := b[2 : 2+mli]
-	if len(p) < 12 { return nil, errors.New("too short for MTI+bitmap") }
+	if len(p) < 12 {
+		return nil, errors.New("too short for MTI+bitmap")
+	}
 	mti := string(p[:4])
-	bitmap := binary.BigEndian.Uint64(p[4:12])
+	primary := binary.BigEndian.Uint64(p[4:12])
 	off := 12
+	var secondary uint64
+	if primary&(1<<63) != 0 {
+		if len(p) < off+8 {
+			return nil, errors.New("too short for secondary bitmap")
+		}
+		secondary = binary.BigEndian.Uint64(p[off : off+8])
+		off += 8
+	}
 
 	m := New(mti)
-	present := func(bit int) bool { return (bitmap & (1 << (64 - bit))) != 0 }
+	present := func(bit int) bool {
+		if bit <= 64 {
+			return (primary & (1 << (64 - bit))) != 0
+		}
+		return (secondary & (1 << (128 - bit))) != 0
+	}
 
-	for f := 1; f <= 64; f++ {
-		if !present(f) { continue }
+	for f := 2; f <= 128; f++ {
+		if !present(f) {
+			continue
+		}
 		switch f {
 		case 7:
-			if off+10 > len(p) { return nil, errors.New("truncated DE7") }
+			if off+10 > len(p) {
+				return nil, errors.New("truncated DE7")
+			}
 			m.Fields[7] = string(p[off : off+10])
 			off += 10
 		case 11:
-			if off+6 > len(p) { return nil, errors.New("truncated DE11") }
+			if off+6 > len(p) {
+				return nil, errors.New("truncated DE11")
+			}
 			m.Fields[11] = string(p[off : off+6])
 			off += 6
 		case 70:
-			if off+3 > len(p) { return nil, errors.New("truncated DE70") }
+			if off+3 > len(p) {
+				return nil, errors.New("truncated DE70")
+			}
 			m.Fields[70] = string(p[off : off+3])
 			off += 3
 		default:
@@ -123,8 +175,12 @@ func NewEchoRequest(stan int) *Message {
 }
 
 func IsEchoResponse(m *Message) bool {
-	if m.MTI != "0810" { return false }
-	if v, ok := m.Get(70); !ok || v != "301" { return false }
+	if m.MTI != "0810" {
+		return false
+	}
+	if v, ok := m.Get(70); !ok || v != "301" {
+		return false
+	}
 	_, ok := m.Get(11)
 	return ok
 }


### PR DESCRIPTION
## Summary
- support secondary bitmap generation and parsing up to field 128
- set bit 1 in primary bitmap when a secondary bitmap is present
- handle secondary bitmap when unpacking ISO8583 messages

## Testing
- `go test ./...`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b3c3ba1d1883278e4d8474d5c1c6d4