### PR TITLE
build field spec registry for ISO8583

### DIFF
--- a/internal/iso8583/iso_test.go
+++ b/internal/iso8583/iso_test.go
@@ -1,0 +1,143 @@
+package iso8583
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestSetGet(t *testing.T) {
+	m := New("0100")
+	m.Set(3, "000000")
+	if v, ok := m.Get(3); !ok || v != "000000" {
+		t.Fatalf("Get returned %q %v", v, ok)
+	}
+}
+
+func TestPackInvalidLength(t *testing.T) {
+	m := New("0200")
+	m.Set(11, "12345") // should be 6
+	if _, err := m.Pack(); err == nil {
+		t.Fatalf("expected error for invalid length")
+	}
+}
+
+func TestPackInvalidMTI(t *testing.T) {
+	m := New("123")
+	m.Set(11, "123456")
+	if _, err := m.Pack(); err == nil {
+		t.Fatalf("expected MTI length error")
+	}
+}
+
+func TestPackUnknownField(t *testing.T) {
+	m := New("0200")
+	m.Set(100, "abc")
+	if _, err := m.Pack(); err == nil || !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("expected spec error, got %v", err)
+	}
+}
+
+func TestPackLLVARTooLong(t *testing.T) {
+	m := New("0200")
+	m.Set(2, strings.Repeat("1", 100))
+	if _, err := m.Pack(); err == nil {
+		t.Fatalf("expected LLVAR length error")
+	}
+}
+
+func TestPackLLLVARTooLong(t *testing.T) {
+	m := New("0200")
+	m.Set(55, strings.Repeat("A", 1000))
+	if _, err := m.Pack(); err == nil {
+		t.Fatalf("expected LLLVAR length error")
+	}
+}
+
+func TestUnpackTruncated(t *testing.T) {
+	m := New("0200")
+	m.Set(7, "0102030405")
+	m.Set(11, "123456")
+	p, err := m.Pack()
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	p = p[:len(p)-1]
+	if _, err := Unpack(p); err == nil {
+		t.Fatalf("expected error for truncated message")
+	}
+}
+
+func TestUnpackUnknownField(t *testing.T) {
+	m := New("0200")
+	m.Set(70, "301") // ensures secondary bitmap
+	p, err := m.Pack()
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	// Set bit 100 in secondary bitmap
+	primaryOffset := 2 + 4
+	secondaryOffset := primaryOffset + 8
+	sec := binary.BigEndian.Uint64(p[secondaryOffset : secondaryOffset+8])
+	sec |= 1 << 28 // bit 100
+	binary.BigEndian.PutUint64(p[secondaryOffset:secondaryOffset+8], sec)
+
+	if _, err := Unpack(p); err == nil || !strings.Contains(err.Error(), "field 100 not implemented") {
+		t.Fatalf("expected unknown field error, got %v", err)
+	}
+}
+
+func TestUnpackExtraBytes(t *testing.T) {
+	m := New("0200")
+	m.Set(11, "123456")
+	p, err := m.Pack()
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	p = append(p, 'X')
+	binary.BigEndian.PutUint16(p[:2], uint16(len(p)-2))
+	if _, err := Unpack(p); err == nil || !strings.Contains(err.Error(), "extra bytes") {
+		t.Fatalf("expected extra bytes error, got %v", err)
+	}
+}
+
+func TestBadDataResponse(t *testing.T) {
+	// Simulate acquirer responding with format error (39=30)
+	m := New("0210")
+	m.Set(39, "30")
+	p, err := m.Pack()
+	if err != nil {
+		t.Fatalf("Pack: %v", err)
+	}
+	m2, err := Unpack(p)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if v, _ := m2.Get(39); v != "30" {
+		t.Fatalf("expected resp code 30, got %q", v)
+	}
+}
+
+func TestEchoHelpers(t *testing.T) {
+	m := NewEchoRequest(123456)
+	if m.MTI != "0800" {
+		t.Fatalf("unexpected MTI %q", m.MTI)
+	}
+	if v, ok := m.Get(70); !ok || v != "301" {
+		t.Fatalf("missing DE70 in echo request")
+	}
+	if MustParseSTAN(m) != 123456%1000000 {
+		t.Fatalf("MustParseSTAN mismatch")
+	}
+
+	resp := New("0810")
+	resp.Set(11, "123456")
+	resp.Set(70, "301")
+	if !IsEchoResponse(resp) {
+		t.Fatalf("IsEchoResponse false for valid response")
+	}
+	resp.Set(70, "999")
+	if IsEchoResponse(resp) {
+		t.Fatalf("IsEchoResponse true for invalid response")
+	}
+}

--- a/internal/iso8583/spec.go
+++ b/internal/iso8583/spec.go
@@ -1,0 +1,55 @@
+package iso8583
+
+// FieldCodec enumerates encoding formats for ISO8583 data elements.
+type FieldCodec int
+
+const (
+	FmtFixedNum FieldCodec = iota // ASCII numeric fixed
+	FmtFixedAns                   // ASCII ans fixed
+	FmtLLVAR                      // ASCII ans LLVAR
+	FmtLLLVAR                     // ASCII ans LLLVAR
+)
+
+// FieldSpec describes an ISO8583 data element.
+type FieldSpec struct {
+	Num   int
+	Name  string
+	Codec FieldCodec
+	Len   int // length for fixed fields
+}
+
+// CommonSpec lists common ISO8583 fields supported by this package.
+var CommonSpec = map[int]FieldSpec{
+	2:   {2, "PAN", FmtLLVAR, 0},
+	3:   {3, "ProcessingCode", FmtFixedNum, 6},
+	4:   {4, "Amount", FmtFixedNum, 12},
+	7:   {7, "TransmissionDateTime", FmtFixedNum, 10},
+	11:  {11, "STAN", FmtFixedNum, 6},
+	12:  {12, "LocalTime", FmtFixedNum, 6},
+	13:  {13, "LocalDate", FmtFixedNum, 4},
+	14:  {14, "Expiry", FmtFixedNum, 4},
+	22:  {22, "POSEntryMode", FmtFixedNum, 3},
+	23:  {23, "PANSeq", FmtFixedNum, 3},
+	24:  {24, "NII", FmtFixedNum, 3},
+	25:  {25, "POSCond", FmtFixedNum, 2},
+	32:  {32, "AcqInstID", FmtLLVAR, 0},
+	35:  {35, "Track2", FmtLLVAR, 0},
+	37:  {37, "RRN", FmtFixedAns, 12},
+	38:  {38, "AuthID", FmtFixedAns, 6},
+	39:  {39, "RespCode", FmtFixedAns, 2},
+	41:  {41, "TermID", FmtFixedAns, 8},
+	42:  {42, "MerchID", FmtFixedAns, 15},
+	43:  {43, "MerchLoc", FmtFixedAns, 40},
+	48:  {48, "AddlDataPriv", FmtLLLVAR, 0},
+	49:  {49, "Currency", FmtFixedAns, 3},
+	52:  {52, "PINBlock", FmtFixedAns, 16},
+	53:  {53, "SecCtrl", FmtFixedNum, 16},
+	54:  {54, "AddlAmounts", FmtLLLVAR, 0},
+	55:  {55, "ICCData", FmtLLLVAR, 0},
+	60:  {60, "AdviceReason/Priv", FmtLLLVAR, 0},
+	61:  {61, "POSExt", FmtLLLVAR, 0},
+	62:  {62, "Priv", FmtLLLVAR, 0},
+	63:  {63, "Priv2", FmtLLLVAR, 0},
+	70:  {70, "NMMCode", FmtFixedNum, 3},
+	102: {102, "AccountID1", FmtLLVAR, 0},
+}


### PR DESCRIPTION
## Summary
- add registry describing common ISO8583 fields and codecs
- refactor Pack/Unpack to drive encoding from spec table
- expand unit test coverage for field validation and echo helpers

## Testing
- `go test ./... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b3dc445ab4832785e608ee18d3fe51